### PR TITLE
Add ApexClasses, Queues and CMDT menu configs and register handlers

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -53,7 +53,7 @@
 								></div>
 							</div>
 							<p id="command-help" class="input-help">
-								Type <code>Objects.</code>, <code>Profiles.</code>, <code>PermSets.</code>, <code>Flows.</code>, <code>Apps.</code>, <code>Labels.</code>, or <code>ESD.</code>
+								Type <code>Objects.</code>, <code>Profiles.</code>, <code>PermSets.</code>, <code>Flows.</code>, <code>Apps.</code>, <code>Labels.</code>, <code>ESD.</code>, <code>ApexClasses.</code>, <code>Queues.</code>, or <code>CMDT.</code>
 							</p>
 						</div>
 
@@ -117,6 +117,31 @@
 									<ul class="guide-list">
 										<li><code>ESD.My Deployment.view</code></li>
 										<li><code>ESD.My Deployment.branding</code></li>
+									</ul>
+								</div>
+
+
+								<div class="guide-group">
+									<h3>ApexClasses</h3>
+									<ul class="guide-list">
+										<li><code>ApexClasses.MyClass.view</code></li>
+										<li><code>ApexClasses.MyClass.edit</code></li>
+									</ul>
+								</div>
+
+								<div class="guide-group">
+									<h3>Queues</h3>
+									<ul class="guide-list">
+										<li><code>Queues.Case Queue.view</code></li>
+										<li><code>Queues.Case Queue.members</code></li>
+									</ul>
+								</div>
+
+								<div class="guide-group">
+									<h3>CMDT</h3>
+									<ul class="guide-list">
+										<li><code>CMDT.My_Type__mdt.view</code></li>
+										<li><code>CMDT.My_Type__mdt.records</code></li>
 									</ul>
 								</div>
 							</div>

--- a/src/features/autocomplete.js
+++ b/src/features/autocomplete.js
@@ -1,12 +1,15 @@
 import SessionManager from '../core/session-manager.js';
 import ErrorHandler from '../utils/error-handler.js';
+import {APEX_CLASSES_MENU_CONFIG} from './menuItems/apexclasses.menu.js';
 import {APPS_MENU_CONFIG} from './menuItems/apps.menu.js';
-import { ESD_MENU_CONFIG } from './menuItems/esd.menu.js';
+import {CMDT_MENU_CONFIG} from './menuItems/cmdt.menu.js';
+import {ESD_MENU_CONFIG} from './menuItems/esd.menu.js';
 import {FLOWS_MENU_CONFIG} from './menuItems/flows.menu.js';
 import { LABELS_MENU_CONFIG } from './menuItems/labels.menu.js';
 import {OBJECTS_MENU_CONFIG} from './menuItems/objects.menu.js';
 import {PERMSETS_MENU_CONFIG} from './menuItems/permsets.menu.js';
 import {PROFILES_MENU_CONFIG} from './menuItems/profiles.menu.js';
+import {QUEUES_MENU_CONFIG} from './menuItems/queues.menu.js';
 import NavigatorService from './navigator.service.js';
 
 // Define constants for better maintainability
@@ -19,6 +22,9 @@ const STATES = {
 	LABEL_SELECTED: 'LABELS_SELECTED',
 	PERMSET_SELECTED: 'PERMSETS_SELECTED',
 	ESD_SELECTED: 'ESD_SELECTED',
+	APEXCLASSES_SELECTED: 'APEXCLASSES_SELECTED',
+	QUEUES_SELECTED: 'QUEUES_SELECTED',
+	CMDT_SELECTED: 'CMDT_SELECTED',
 	BOTS_SELECTED: 'BOTS_SELECTED'
 };
 
@@ -32,6 +38,9 @@ const STATE_STORE = {
 	[STATES.LABEL_SELECTED]: {CONFIG: {}, DATA: []},
 	[STATES.PERMSET_SELECTED]: {CONFIG: {}, DATA: []},
 	[STATES.ESD_SELECTED]: {CONFIG: {}, DATA: []},
+	[STATES.APEXCLASSES_SELECTED]: {CONFIG: {}, DATA: []},
+	[STATES.QUEUES_SELECTED]: {CONFIG: {}, DATA: []},
+	[STATES.CMDT_SELECTED]: {CONFIG: {}, DATA: []},
 	[STATES.BOTS_SELECTED]: {CONFIG: {}, DATA: []},
 };
 
@@ -42,7 +51,10 @@ const newEntityHandlers = {
 	flows: FLOWS_MENU_CONFIG,
 	permsets: PERMSETS_MENU_CONFIG,
 	labels: LABELS_MENU_CONFIG,
-	esd: ESD_MENU_CONFIG
+	esd: ESD_MENU_CONFIG,
+	apexclasses: APEX_CLASSES_MENU_CONFIG,
+	queues: QUEUES_MENU_CONFIG,
+	cmdt: CMDT_MENU_CONFIG
 };
 
 export function parseCommandInput(rawInput) {
@@ -104,7 +116,7 @@ class AutocompleteManager {
 		if (!parsedCommand) {
 			console.log('Input does not contain a valid entity prefix');
 			this.currentState = STATES.INITIAL;
-			this.renderStatusMessage('Start with a command like Objects. or Profiles.');
+			this.renderStatusMessage('Start with a command like Objects., Profiles., ApexClasses., Queues., or CMDT.');
 			return;
 		}
 

--- a/src/features/menuItems/apexclasses.menu.js
+++ b/src/features/menuItems/apexclasses.menu.js
@@ -1,0 +1,37 @@
+export const APEX_CLASSES_MENU_CONFIG = {
+	prefix: 'ApexClasses',
+	queryType: 'TOOLING',
+	filterKey: ['name', 'namespace', 'status'],
+	query: 'SELECT Id,Name,NamespacePrefix,Status,ApiVersion FROM ApexClass',
+	processResult: result =>
+		result.records.map(apexClass => ({
+			id: apexClass.Id,
+			name: apexClass.Name,
+			namespace: apexClass.NamespacePrefix || 'local',
+			status: apexClass.Status || 'Unknown',
+			apiVersion: apexClass.ApiVersion,
+		})),
+	getItemIdentifier: apexClass => apexClass.name,
+	renderItem: apexClass => `
+        <strong>${apexClass.name}</strong>
+        <small>[${apexClass.namespace}] • v${apexClass.apiVersion} • ${apexClass.status}</small>
+      `,
+	urlConfig: (session, apexClass, action) => {
+		const baseUrl = `https://${session.fullHostname}`;
+
+		if (action === 'edit') {
+			return `${baseUrl}/${apexClass.id}/e`;
+		}
+
+		if (action === 'security') {
+			return `${baseUrl}/lightning/setup/ApexClasses/page?address=%2F${apexClass.id}%3Fs%3DApexClassSecurity`;
+		}
+
+		return `${baseUrl}/lightning/setup/ApexClasses/page?address=%2F${apexClass.id}%3F`;
+	},
+	actions: [
+		{code: 'view', name: 'View Class', description: 'Open Apex class detail page'},
+		{code: 'edit', name: 'Edit Class', description: 'Open class editor'},
+		{code: 'security', name: 'Class Access', description: 'Open class security assignments'},
+	],
+};

--- a/src/features/menuItems/cmdt.menu.js
+++ b/src/features/menuItems/cmdt.menu.js
@@ -1,0 +1,39 @@
+export const CMDT_MENU_CONFIG = {
+	prefix: 'CMDT',
+	queryType: 'REST',
+	filterKey: ['label', 'apiName', 'namespace'],
+	query: 'query?q=SELECT+Id,Label,QualifiedApiName,NamespacePrefix+FROM+EntityDefinition+WHERE+QualifiedApiName+LIKE+%27%25__mdt%27',
+	processResult: result =>
+		result.records.map(type => ({
+			id: type.Id,
+			label: type.Label,
+			apiName: type.QualifiedApiName,
+			namespace: type.NamespacePrefix || 'local',
+		})),
+	getItemIdentifier: cmdt => cmdt.apiName,
+	renderItem: cmdt => `
+        <strong>${cmdt.label}</strong>
+        <small>(${cmdt.apiName})</small>
+        <div class="cmdt-details">
+          <small>Namespace: ${cmdt.namespace}</small>
+        </div>
+      `,
+	urlConfig: (session, cmdt, action) => {
+		const baseUrl = `https://${session.fullHostname}`;
+
+		if (action === 'records') {
+			return `${baseUrl}/lightning/o/${cmdt.apiName}/list`;
+		}
+
+		if (action === 'fields') {
+			return `${baseUrl}/lightning/setup/CustomMetadata/page?address=%2F${cmdt.id}%3Fs%3DCustomFields`;
+		}
+
+		return `${baseUrl}/lightning/setup/CustomMetadata/page?address=%2F${cmdt.id}%3F`;
+	},
+	actions: [
+		{code: 'view', name: 'View Type', description: 'Open custom metadata type setup'},
+		{code: 'records', name: 'Type Records', description: 'Open custom metadata records list'},
+		{code: 'fields', name: 'Type Fields', description: 'Open custom metadata fields'},
+	],
+};

--- a/src/features/menuItems/queues.menu.js
+++ b/src/features/menuItems/queues.menu.js
@@ -1,0 +1,39 @@
+export const QUEUES_MENU_CONFIG = {
+	prefix: 'Queues',
+	queryType: 'REST',
+	filterKey: ['name', 'developerName', 'email'],
+	query: 'query?q=SELECT+Id,Name,DeveloperName,Email+FROM+Group+WHERE+Type+%3D+%27Queue%27',
+	processResult: result =>
+		result.records.map(queue => ({
+			id: queue.Id,
+			name: queue.Name,
+			developerName: queue.DeveloperName || queue.Name,
+			email: queue.Email || 'No queue email',
+		})),
+	getItemIdentifier: queue => queue.name,
+	renderItem: queue => `
+        <strong>${queue.name}</strong>
+        <small>(${queue.developerName})</small>
+        <div class="queue-details">
+          <small>${queue.email}</small>
+        </div>
+      `,
+	urlConfig: (session, queue, action) => {
+		const baseUrl = `https://${session.fullHostname}`;
+
+		if (action === 'members') {
+			return `${baseUrl}/lightning/setup/Queues/page?address=%2F${queue.id}%3Fs%3DQueueMembers`;
+		}
+
+		if (action === 'objects') {
+			return `${baseUrl}/lightning/setup/Queues/page?address=%2F${queue.id}%3Fs%3DSupportedObjects`;
+		}
+
+		return `${baseUrl}/lightning/setup/Queues/page?address=%2F${queue.id}%3F`;
+	},
+	actions: [
+		{code: 'view', name: 'View Queue', description: 'Open queue details'},
+		{code: 'members', name: 'Queue Members', description: 'Manage users and groups in this queue'},
+		{code: 'objects', name: 'Supported Objects', description: 'View objects assigned to this queue'},
+	],
+};

--- a/tests/autocomplete.test.js
+++ b/tests/autocomplete.test.js
@@ -23,6 +23,39 @@ test('parseCommandInput tracks trailing dot for action menus', () => {
 	assert.equal(parsed.endsWithDot, true);
 });
 
+test('parseCommandInput supports ApexClasses command flow', () => {
+	const parsed = parseCommandInput('ApexClasses.CaseRouter.security');
+
+	assert.deepEqual(parsed, {
+		entityKey: 'apexclasses',
+		searchTerm: 'caserouter',
+		actionTerm: 'security',
+		endsWithDot: false,
+	});
+});
+
+test('parseCommandInput supports Queues command flow with spaces', () => {
+	const parsed = parseCommandInput('Queues.Case Queue.members');
+
+	assert.deepEqual(parsed, {
+		entityKey: 'queues',
+		searchTerm: 'case queue',
+		actionTerm: 'members',
+		endsWithDot: false,
+	});
+});
+
+test('parseCommandInput supports CMDT command flow and trailing dot', () => {
+	const parsed = parseCommandInput('CMDT.Invoice_Config__mdt.');
+
+	assert.deepEqual(parsed, {
+		entityKey: 'cmdt',
+		searchTerm: 'invoice_config__mdt',
+		actionTerm: '',
+		endsWithDot: true,
+	});
+});
+
 test('parseCommandInput returns null for unsupported prefixes', () => {
 	assert.equal(parseCommandInput('foo.bar'), null);
 });


### PR DESCRIPTION
### Motivation
- Extend the navigator to support quick commands for Apex classes, Queues, and Custom Metadata Types (CMDT) so users can jump to those setup pages from the command palette.
- Keep URL generation and action flows consistent with existing `objects.menu.js` and `profiles.menu.js` patterns so navigation works predictably across entities.

### Description
- Added new menu config modules: `src/features/menuItems/apexclasses.menu.js`, `src/features/menuItems/queues.menu.js`, and `src/features/menuItems/cmdt.menu.js` with `queryType`, queries, `filterKey`, `getItemIdentifier`, `actions`, `processResult`, and `urlConfig` implementations.
- Registered the new handlers in `src/features/autocomplete.js` by importing the configs, adding new `STATES` and `STATE_STORE` entries, and adding `apexclasses`, `queues`, and `cmdt` to `newEntityHandlers` so the parser resolves the prefixes.
- Updated UI help and quick-guide examples in `popup.html` to list `ApexClasses.`, `Queues.`, and `CMDT.` usage examples.
- Added parsing/flow unit tests in `tests/autocomplete.test.js` to cover `ApexClasses`, `Queues`, and `CMDT` command patterns and trailing-dot behavior.

### Testing
- Ran `npm test` and all test cases passed (including new parsing tests).
- Ran `npm run check:syntax` and the syntax checks passed.
- Ran `npm run lint` which reported pre-existing `no-unused-vars` errors in `src/core/session-manager.js` and `src/utils/domain-validator.js`; these lint errors are unrelated to the changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5ec7086d4832786b9a4f7c8b054af)