### PR TITLE
Implement autocomplete keyboard navigation, active-item state, and ARIA updates

### DIFF
--- a/popus.js
+++ b/popus.js
@@ -18,6 +18,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
 		const autocompleteManager = new AutocompleteManager(objectInput, autocompleteDropdown);
 		objectInput.addEventListener('input', e => autocompleteManager.handleAutocomplete(e));
+		objectInput.addEventListener('keydown', e => autocompleteManager.handleKeydown(e));
 
 		const guideCodes = document.querySelectorAll('.guide-first-level');
 		setupGuideCodeClickListeners(guideCodes, objectInput);

--- a/src/features/autocomplete.js
+++ b/src/features/autocomplete.js
@@ -45,6 +45,13 @@ const newEntityHandlers = {
 	esd: ESD_MENU_CONFIG
 };
 
+const KEYBOARD_KEYS = {
+	ARROW_DOWN: 'ArrowDown',
+	ARROW_UP: 'ArrowUp',
+	ENTER: 'Enter',
+	ESCAPE: 'Escape',
+};
+
 export function parseCommandInput(rawInput) {
 	const normalizedInput = rawInput.trim().toLowerCase();
 	const segments = normalizedInput.split('.');
@@ -62,11 +69,43 @@ export function parseCommandInput(rawInput) {
 	};
 }
 
+export function getNextActiveIndex(currentIndex, itemCount, direction) {
+	if (itemCount <= 0) {
+		return -1;
+	}
+
+	if (direction === KEYBOARD_KEYS.ARROW_DOWN) {
+		if (currentIndex < 0) {
+			return 0;
+		}
+
+		return (currentIndex + 1) % itemCount;
+	}
+
+	if (direction === KEYBOARD_KEYS.ARROW_UP) {
+		if (currentIndex < 0) {
+			return itemCount - 1;
+		}
+
+		return (currentIndex - 1 + itemCount) % itemCount;
+	}
+
+	return currentIndex;
+}
+
 class AutocompleteManager {
 	constructor(inputElement, dropdownElement) {
 		this.inputElement = inputElement;
 		this.dropdownElement = dropdownElement;
 		this.currentState = STATES.INITIAL;
+		this.activeIndices = {
+			suggestion: -1,
+			action: -1,
+		};
+
+		this.dropdownElement.setAttribute('role', 'listbox');
+		this.inputElement.setAttribute('aria-controls', this.dropdownElement.id);
+		this.inputElement.setAttribute('aria-activedescendant', '');
 	}
 
 	async handleAutocomplete(e) {
@@ -93,6 +132,74 @@ class AutocompleteManager {
 			ErrorHandler.handle(error, error.message || 'Autocomplete error');
 			this.resetAutocomplete();
 		}
+	}
+
+	handleKeydown(e) {
+		const supportedKey = Object.values(KEYBOARD_KEYS).includes(e.key);
+		if (!supportedKey) {
+			return;
+		}
+
+		if (e.key === KEYBOARD_KEYS.ESCAPE) {
+			e.preventDefault();
+			this.resetAutocomplete();
+			return;
+		}
+
+		const clickableItems = this.getClickableItems();
+		if (clickableItems.length === 0) {
+			return;
+		}
+
+		const listType = clickableItems[0]?.dataset?.itemType || 'suggestion';
+		const currentIndex = this.activeIndices[listType] ?? -1;
+
+		if (e.key === KEYBOARD_KEYS.ARROW_DOWN || e.key === KEYBOARD_KEYS.ARROW_UP) {
+			e.preventDefault();
+			const nextIndex = getNextActiveIndex(currentIndex, clickableItems.length, e.key);
+			this.setActiveItem(listType, nextIndex);
+			return;
+		}
+
+		if (e.key === KEYBOARD_KEYS.ENTER) {
+			const highlightedIndex = this.activeIndices[listType];
+			if (highlightedIndex >= 0 && highlightedIndex < clickableItems.length) {
+				e.preventDefault();
+				clickableItems[highlightedIndex].click();
+			}
+		}
+	}
+
+	getClickableItems() {
+		return Array.from(this.dropdownElement.querySelectorAll('.autocomplete-item.is-clickable'));
+	}
+
+	setActiveItem(listType, index) {
+		const clickableItems = this.getClickableItems();
+		clickableItems.forEach(item => {
+			item.classList.remove('is-active');
+			item.setAttribute('aria-selected', 'false');
+		});
+
+		if (index < 0 || index >= clickableItems.length) {
+			this.activeIndices[listType] = -1;
+			this.inputElement.setAttribute('aria-activedescendant', '');
+			return;
+		}
+
+		const activeItem = clickableItems[index];
+		activeItem.classList.add('is-active');
+		activeItem.setAttribute('aria-selected', 'true');
+		this.inputElement.setAttribute('aria-activedescendant', activeItem.id || '');
+		this.activeIndices[listType] = index;
+	}
+
+	resetActiveIndices() {
+		this.activeIndices = {
+			suggestion: -1,
+			action: -1,
+		};
+		this.inputElement.setAttribute('aria-activedescendant', '');
 	}
 
 	async handleInputText(input) {
@@ -147,6 +254,7 @@ class AutocompleteManager {
 
 		if (exactMatchItem && (endsWithDot || actionTerm)) {
 			NavigatorService.renderItemActions(exactMatchItem, this.dropdownElement, this.inputElement, selectedEntity, actionTerm);
+			this.resetActiveIndices();
 			return;
 		}
 
@@ -157,6 +265,7 @@ class AutocompleteManager {
 
 		// Render suggestions
 		await NavigatorService.renderSuggestions(filteredItems, this.dropdownElement, this.inputElement, selectedEntity);
+		this.resetActiveIndices();
 	}
 
 	resetAutocomplete() {
@@ -164,12 +273,14 @@ class AutocompleteManager {
 		this.dropdownElement.classList.add('is-hidden');
 		this.dropdownElement.style.display = 'none';
 		this.dropdownElement.innerHTML = '';
+		this.resetActiveIndices();
 	}
 
 	renderStatusMessage(message) {
 		this.dropdownElement.innerHTML = `<div class="autocomplete-item">${message}</div>`;
 		this.dropdownElement.classList.remove('is-hidden');
 		this.dropdownElement.style.display = 'block';
+		this.resetActiveIndices();
 	}
 
 	static async queryWithErrorHandling(apiCall, errorMessage) {

--- a/src/features/autocomplete/dom-utils.js
+++ b/src/features/autocomplete/dom-utils.js
@@ -2,12 +2,18 @@ export function renderSuggestions(items, dropdownElement, inputElement, config) 
 	dropdownElement.innerHTML = '';
 	dropdownElement.classList.add('is-hidden');
 	dropdownElement.style.display = 'none';
+	dropdownElement.dataset.listType = 'suggestion';
 
 	if (items.length === 0) return;
 
-	items.slice(0, 10).forEach(item => {
+	items.slice(0, 10).forEach((item, index) => {
 		const suggestionEl = document.createElement('div');
 		suggestionEl.classList.add('autocomplete-item', 'is-clickable');
+		suggestionEl.id = `autocomplete-suggestion-${index}`;
+		suggestionEl.dataset.itemType = 'suggestion';
+		suggestionEl.dataset.itemIndex = String(index);
+		suggestionEl.setAttribute('role', 'option');
+		suggestionEl.setAttribute('aria-selected', 'false');
 		suggestionEl.innerHTML = config.renderItem(item);
 
 		suggestionEl.addEventListener('click', () => {
@@ -24,6 +30,7 @@ export function renderSuggestions(items, dropdownElement, inputElement, config) 
 
 export function renderActions(item, dropdownElement, inputElement, actions, config) {
 	dropdownElement.innerHTML = '';
+	dropdownElement.dataset.listType = 'action';
 
 	const normalizedActionTerm = (config.actionTerm || '').toLowerCase();
 	const filteredActions = actions.filter(action => {
@@ -41,9 +48,14 @@ export function renderActions(item, dropdownElement, inputElement, actions, conf
 		return;
 	}
 
-	filteredActions.forEach(action => {
+	filteredActions.forEach((action, index) => {
 		const actionEl = document.createElement('div');
 		actionEl.classList.add('autocomplete-item', 'is-clickable');
+		actionEl.id = `autocomplete-action-${index}`;
+		actionEl.dataset.itemType = 'action';
+		actionEl.dataset.itemIndex = String(index);
+		actionEl.setAttribute('role', 'option');
+		actionEl.setAttribute('aria-selected', 'false');
 		actionEl.innerHTML = `
 			<strong>${action.name}</strong>
 			<small>${action.description}</small>

--- a/styles/autocomplete.css
+++ b/styles/autocomplete.css
@@ -52,3 +52,9 @@
 .autocomplete-item:hover {
 	background-color: rgba(25, 113, 194, 0.06);
 }
+
+.autocomplete-item.is-active {
+	background-color: rgba(25, 113, 194, 0.12);
+	outline: 2px solid rgba(25, 113, 194, 0.35);
+	outline-offset: -2px;
+}

--- a/tests/autocomplete.test.js
+++ b/tests/autocomplete.test.js
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import {parseCommandInput} from '../src/features/autocomplete.js';
+import AutocompleteManager, {getNextActiveIndex, parseCommandInput} from '../src/features/autocomplete.js';
 
 test('parseCommandInput extracts entity, search term, and action term', () => {
 	const parsed = parseCommandInput('Objects.Case.Details');
@@ -26,3 +26,99 @@ test('parseCommandInput tracks trailing dot for action menus', () => {
 test('parseCommandInput returns null for unsupported prefixes', () => {
 	assert.equal(parseCommandInput('foo.bar'), null);
 });
+
+test('getNextActiveIndex cycles correctly for ArrowDown and ArrowUp', () => {
+	assert.equal(getNextActiveIndex(-1, 3, 'ArrowDown'), 0);
+	assert.equal(getNextActiveIndex(0, 3, 'ArrowDown'), 1);
+	assert.equal(getNextActiveIndex(2, 3, 'ArrowDown'), 0);
+
+	assert.equal(getNextActiveIndex(-1, 3, 'ArrowUp'), 2);
+	assert.equal(getNextActiveIndex(2, 3, 'ArrowUp'), 1);
+	assert.equal(getNextActiveIndex(0, 3, 'ArrowUp'), 2);
+});
+
+test('handleKeydown Enter triggers click on highlighted suggestion', () => {
+	const itemA = createClickableItem('autocomplete-suggestion-0', 'suggestion');
+	const itemB = createClickableItem('autocomplete-suggestion-1', 'suggestion');
+	const manager = createManager([itemA, itemB]);
+	manager.activeIndices.suggestion = 1;
+
+	const event = createKeyboardEvent('Enter');
+	manager.handleKeydown(event);
+
+	assert.equal(event.defaultPrevented, true);
+	assert.equal(itemA.clickCount, 0);
+	assert.equal(itemB.clickCount, 1);
+});
+
+test('handleKeydown ArrowDown updates active descendant and selected state', () => {
+	const itemA = createClickableItem('autocomplete-action-0', 'action');
+	const itemB = createClickableItem('autocomplete-action-1', 'action');
+	const manager = createManager([itemA, itemB]);
+
+	manager.handleKeydown(createKeyboardEvent('ArrowDown'));
+
+	assert.equal(manager.activeIndices.action, 0);
+	assert.equal(itemA.classList.contains('is-active'), true);
+	assert.equal(itemA.attributes['aria-selected'], 'true');
+	assert.equal(itemB.attributes['aria-selected'], 'false');
+	assert.equal(manager.inputElement.attributes['aria-activedescendant'], 'autocomplete-action-0');
+});
+
+function createKeyboardEvent(key) {
+	return {
+		key,
+		defaultPrevented: false,
+		preventDefault() {
+			this.defaultPrevented = true;
+		},
+	};
+}
+
+function createManager(items) {
+	const inputElement = createInputElement();
+	const dropdownElement = {
+		id: 'autocompleteDropdown',
+		querySelectorAll: () => items,
+		setAttribute() {},
+	};
+
+	return new AutocompleteManager(inputElement, dropdownElement);
+}
+
+function createInputElement() {
+	return {
+		attributes: {},
+		setAttribute(name, value) {
+			this.attributes[name] = value;
+		},
+	};
+}
+
+function createClickableItem(id, itemType) {
+	const classes = new Set(['autocomplete-item', 'is-clickable']);
+
+	return {
+		id,
+		dataset: {itemType},
+		attributes: {'aria-selected': 'false'},
+		clickCount: 0,
+		classList: {
+			add(value) {
+				classes.add(value);
+			},
+			remove(value) {
+				classes.delete(value);
+			},
+			contains(value) {
+				return classes.has(value);
+			},
+		},
+		setAttribute(name, value) {
+			this.attributes[name] = value;
+		},
+		click() {
+			this.clickCount += 1;
+		},
+	};
+}


### PR DESCRIPTION
### Motivation
- Provide keyboard navigation for the autocomplete so users can move through suggestions and actions with `ArrowUp`/`ArrowDown`. 
- Ensure `Enter` triggers the same behavior as clicking a highlighted row so keyboard and mouse interactions match. 
- Improve accessibility with ARIA attributes and visible focus/highlight styling for the active row.

### Description
- Added an index-based selection model (`activeIndices`) and helper `getNextActiveIndex` to `src/features/autocomplete.js` to track highlighted rows for both `suggestion` and `action` lists. 
- Implemented `handleKeydown` in `src/features/autocomplete.js` to handle `ArrowDown`, `ArrowUp`, `Enter`, and `Escape`, and wired the handler to the input in `popus.js` via `objectInput.addEventListener('keydown', ...)`. 
- Made `Enter` activate the highlighted row by invoking the row's `.click()` so keyboard selection matches click behavior. 
- Added ARIA/listbox semantics: `role=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5ec693fb4832794edaefec6563819)