### PR TITLE
Add popup command history and pinning with storage-backed service

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -57,6 +57,24 @@
 							</p>
 						</div>
 
+						<div class="history-sections" aria-label="Command history">
+							<section class="history-section" aria-labelledby="pinned-commands-title">
+								<div class="history-header">
+									<h3 id="pinned-commands-title">Pinned</h3>
+								</div>
+								<p id="pinnedCommandsEmpty" class="history-empty">No pinned commands yet.</p>
+								<ul id="pinnedCommandsList" class="history-list" aria-live="polite"></ul>
+							</section>
+
+							<section class="history-section" aria-labelledby="recent-commands-title">
+								<div class="history-header">
+									<h3 id="recent-commands-title">Recent</h3>
+								</div>
+								<p id="recentCommandsEmpty" class="history-empty">No recent commands yet.</p>
+								<ul id="recentCommandsList" class="history-list" aria-live="polite"></ul>
+							</section>
+						</div>
+
 						<div class="quick-guide-inline" aria-labelledby="quick-guide-inline-title">
 							<div class="panel-header panel-header-inline">
 								<h2 id="quick-guide-inline-title">Quick Guide</h2>

--- a/popus.js
+++ b/popus.js
@@ -1,3 +1,4 @@
+import CommandHistoryService from './src/core/command-history.js';
 import AutocompleteManager from './src/features/autocomplete.js';
 import DomainValidator from './src/utils/domain-validator.js';
 
@@ -6,6 +7,10 @@ document.addEventListener('DOMContentLoaded', async () => {
 	const autocompleteDropdown = document.getElementById('autocompleteDropdown');
 	const container = document.querySelector('.container');
 	const notSalesforceMessage = document.getElementById('not-salesforce-message');
+	const pinnedList = document.getElementById('pinnedCommandsList');
+	const recentList = document.getElementById('recentCommandsList');
+	const pinnedEmpty = document.getElementById('pinnedCommandsEmpty');
+	const recentEmpty = document.getElementById('recentCommandsEmpty');
 
 	try {
 		const isSalesforceDomain = await DomainValidator.isOnSalesforceDomain();
@@ -19,6 +24,49 @@ document.addEventListener('DOMContentLoaded', async () => {
 		const autocompleteManager = new AutocompleteManager(objectInput, autocompleteDropdown);
 		objectInput.addEventListener('input', e => autocompleteManager.handleAutocomplete(e));
 
+		const applyCommandSelection = command => {
+			objectInput.value = command;
+			objectInput.focus();
+			objectInput.dispatchEvent(new Event('input', {bubbles: true}));
+		};
+
+		const renderHistory = async () => {
+			const [recentCommands, pinnedCommands] = await Promise.all([
+				CommandHistoryService.listRecent(),
+				CommandHistoryService.listPinned(),
+			]);
+
+			renderCommandList({
+				listElement: pinnedList,
+				emptyElement: pinnedEmpty,
+				commands: pinnedCommands,
+				onSelect: applyCommandSelection,
+				onTogglePin: async command => {
+					await CommandHistoryService.unpinCommand(command);
+					await renderHistory();
+				},
+				pinLabel: 'Unpin',
+			});
+
+			renderCommandList({
+				listElement: recentList,
+				emptyElement: recentEmpty,
+				commands: recentCommands,
+				onSelect: applyCommandSelection,
+				onTogglePin: async command => {
+					if (pinnedCommands.includes(command)) {
+						await CommandHistoryService.unpinCommand(command);
+					} else {
+						await CommandHistoryService.pinCommand(command);
+					}
+					await renderHistory();
+				},
+				getPinLabel: command => (pinnedCommands.includes(command) ? 'Unpin' : 'Pin'),
+			});
+		};
+
+		await renderHistory();
+
 		const guideCodes = document.querySelectorAll('.guide-first-level');
 		setupGuideCodeClickListeners(guideCodes, objectInput);
 	} catch (error) {
@@ -28,19 +76,49 @@ document.addEventListener('DOMContentLoaded', async () => {
 
 function setupGuideCodeClickListeners(guideCodes, objectInput) {
 	guideCodes.forEach(code => {
-		code.style.cursor = 'pointer'; // Indicate clickable elements
+		code.style.cursor = 'pointer';
 		code.addEventListener('click', () => updateInputWithGuideCode(code, objectInput));
 	});
 }
 
 function updateInputWithGuideCode(codeElement, objectInput) {
 	const guideText = codeElement.textContent.trim();
-
-	// Update the input value and focus the input field
-	objectInput.value = guideText+'.'; // Add a period to the end of the guide code
+	objectInput.value = `${guideText}.`;
 	objectInput.focus();
 
-	// Dispatch an input event to trigger autocomplete functionality
 	const event = new Event('input', {bubbles: true});
 	objectInput.dispatchEvent(event);
+}
+
+function renderCommandList({listElement, emptyElement, commands, onSelect, onTogglePin, pinLabel, getPinLabel}) {
+	listElement.innerHTML = '';
+
+	if (!commands.length) {
+		emptyElement.classList.remove('is-hidden');
+		return;
+	}
+
+	emptyElement.classList.add('is-hidden');
+	commands.forEach(command => {
+		const listItem = document.createElement('li');
+		listItem.classList.add('history-item');
+
+		const commandButton = document.createElement('button');
+		commandButton.type = 'button';
+		commandButton.classList.add('history-command-button');
+		commandButton.textContent = command;
+		commandButton.addEventListener('click', () => onSelect(command));
+
+		const pinButton = document.createElement('button');
+		pinButton.type = 'button';
+		pinButton.classList.add('history-pin-button');
+		pinButton.textContent = getPinLabel ? getPinLabel(command) : pinLabel;
+		pinButton.addEventListener('click', async event => {
+			event.stopPropagation();
+			await onTogglePin(command);
+		});
+
+		listItem.append(commandButton, pinButton);
+		listElement.appendChild(listItem);
+	});
 }

--- a/src/core/command-history.js
+++ b/src/core/command-history.js
@@ -1,0 +1,88 @@
+const STORAGE_KEYS = {
+	recent: 'commandHistoryRecent',
+	pinned: 'commandHistoryPinned',
+};
+
+const MAX_RECENT_COMMANDS = 20;
+
+export function normalizeCommand(command = '') {
+	return command.trim().replace(/\s+/g, ' ');
+}
+
+function uniqMostRecent(commands) {
+	const seen = new Set();
+	const deduped = [];
+
+	commands.forEach(command => {
+		if (!command || seen.has(command)) {
+			return;
+		}
+
+		seen.add(command);
+		deduped.push(command);
+	});
+
+	return deduped;
+}
+
+export function buildRecentCommands(nextCommand, existing = [], max = MAX_RECENT_COMMANDS) {
+	const normalized = normalizeCommand(nextCommand);
+	if (!normalized) {
+		return uniqMostRecent(existing.map(normalizeCommand)).slice(0, max);
+	}
+
+	const allCommands = [normalized, ...existing.map(normalizeCommand)];
+	return uniqMostRecent(allCommands).slice(0, max);
+}
+
+function readStorage(keys) {
+	return chrome.storage.local.get(keys);
+}
+
+function writeStorage(data) {
+	return chrome.storage.local.set(data);
+}
+
+class CommandHistoryService {
+	static async listRecent() {
+		const result = await readStorage([STORAGE_KEYS.recent]);
+		const recent = result[STORAGE_KEYS.recent] || [];
+		return uniqMostRecent(recent.map(normalizeCommand)).slice(0, MAX_RECENT_COMMANDS);
+	}
+
+	static async listPinned() {
+		const result = await readStorage([STORAGE_KEYS.pinned]);
+		const pinned = result[STORAGE_KEYS.pinned] || [];
+		return uniqMostRecent(pinned.map(normalizeCommand));
+	}
+
+	static async addRecent(command) {
+		const recent = await CommandHistoryService.listRecent();
+		const nextRecent = buildRecentCommands(command, recent, MAX_RECENT_COMMANDS);
+		await writeStorage({[STORAGE_KEYS.recent]: nextRecent});
+		return nextRecent;
+	}
+
+	static async pinCommand(command) {
+		const normalized = normalizeCommand(command);
+		if (!normalized) {
+			return CommandHistoryService.listPinned();
+		}
+
+		const pinned = await CommandHistoryService.listPinned();
+		const nextPinned = uniqMostRecent([normalized, ...pinned]);
+		await writeStorage({[STORAGE_KEYS.pinned]: nextPinned});
+		return nextPinned;
+	}
+
+	static async unpinCommand(command) {
+		const normalized = normalizeCommand(command);
+		const pinned = await CommandHistoryService.listPinned();
+		const nextPinned = pinned.filter(item => item !== normalized);
+		await writeStorage({[STORAGE_KEYS.pinned]: nextPinned});
+		return nextPinned;
+	}
+}
+
+export {MAX_RECENT_COMMANDS};
+export default CommandHistoryService;

--- a/src/features/autocomplete/dom-utils.js
+++ b/src/features/autocomplete/dom-utils.js
@@ -52,7 +52,7 @@ export function renderActions(item, dropdownElement, inputElement, actions, conf
 		actionEl.addEventListener('click', () => {
 			inputElement.value = `${config.prefix}.${config.getItemIdentifier(item)}.${action.code}`;
 			dropdownElement.style.display = 'none';
-			config.navigate(item, action.code);
+			config.navigate(item, action.code, inputElement.value);
 		});
 
 		dropdownElement.appendChild(actionEl);

--- a/src/features/navigator.service.js
+++ b/src/features/navigator.service.js
@@ -2,6 +2,7 @@ import SalesforceApiService from '../core/api-service.js';
 import SessionManager from '../core/session-manager.js';
 import ErrorHandler from '../utils/error-handler.js';
 import AutocompleteManager from './autocomplete.js';
+import CommandHistoryService from '../core/command-history.js';
 import {renderActions, renderSuggestions} from './autocomplete/dom-utils.js';
 
 class NavigatorService {
@@ -22,7 +23,7 @@ class NavigatorService {
 		}, config.errorMessage || 'Error querying metadata');
 	}
 
-	static async navigateToItem(item, action, urlConfig) {
+	static async navigateToItem(item, action, urlConfig, commandInput = '') {
 		console.log('Navigating to item:', item, action);
 		try {
 			const session = await SessionManager.retrieveSession();
@@ -30,7 +31,8 @@ class NavigatorService {
 
 			navigateUrl = urlConfig(session, item, action);
 
-			chrome.tabs.create({url: navigateUrl});
+			await chrome.tabs.create({url: navigateUrl});
+			await CommandHistoryService.addRecent(commandInput);
 		} catch (error) {
 			ErrorHandler.handle(error, 'Navigation Error');
 		}
@@ -43,7 +45,7 @@ class NavigatorService {
 			renderItem: config.renderItem,
 			getItemIdentifier: config.getItemIdentifier,
 			renderActions: (item, dropdown, input) => NavigatorService.renderItemActions(item, dropdown, input, config),
-			navigate: (item, action) => NavigatorService.navigateToItem(item, action, config.urlConfig),
+			navigate: (item, action, commandInput) => NavigatorService.navigateToItem(item, action, config.urlConfig, commandInput),
 		};
 
 		renderSuggestions(items, dropdownElement, inputElement, fullConfig);
@@ -54,7 +56,7 @@ class NavigatorService {
 			prefix: config.prefix,
 			getItemIdentifier: config.getItemIdentifier,
 			actionTerm,
-			navigate: (item, action) => NavigatorService.navigateToItem(item, action, config.urlConfig),
+			navigate: (item, action, commandInput) => NavigatorService.navigateToItem(item, action, config.urlConfig, commandInput),
 		};
 
 		renderActions(item, dropdownElement, inputElement, config.actions, actionConfig);

--- a/styles/popup.css
+++ b/styles/popup.css
@@ -320,3 +320,77 @@ body {
 	background: rgba(25, 113, 194, 0.42);
 	border-radius: 999px;
 }
+
+.history-sections {
+	display: grid;
+	grid-template-columns: 1fr;
+	gap: 10px;
+	margin-top: 4px;
+}
+
+.history-section {
+	padding: 10px 12px;
+	border-radius: 12px;
+	border: 1px solid rgba(23, 50, 77, 0.1);
+	background: rgba(255, 255, 255, 0.85);
+}
+
+.history-header h3 {
+	font-size: 0.76rem;
+	font-weight: 700;
+	letter-spacing: 0.06em;
+	text-transform: uppercase;
+	color: var(--color-muted);
+}
+
+.history-empty {
+	margin-top: 8px;
+	font-size: 0.78rem;
+	color: var(--color-muted);
+}
+
+.history-list {
+	list-style: none;
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+	margin-top: 8px;
+}
+
+.history-item {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) auto;
+	gap: 8px;
+}
+
+.history-command-button,
+.history-pin-button {
+	border: 1px solid rgba(23, 50, 77, 0.14);
+	background: #fff;
+	border-radius: 8px;
+	padding: 6px 8px;
+	font-size: 0.78rem;
+	color: var(--color-ink);
+	cursor: pointer;
+}
+
+.history-command-button {
+	text-align: left;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.history-pin-button {
+	font-size: 0.74rem;
+	font-weight: 700;
+	color: var(--color-primary);
+}
+
+.history-command-button:hover,
+.history-pin-button:hover,
+.history-command-button:focus-visible,
+.history-pin-button:focus-visible {
+	border-color: rgba(25, 113, 194, 0.45);
+	outline: none;
+}

--- a/tests/command-history.test.js
+++ b/tests/command-history.test.js
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {buildRecentCommands, MAX_RECENT_COMMANDS, normalizeCommand} from '../src/core/command-history.js';
+
+test('normalizeCommand trims and collapses whitespace', () => {
+	assert.equal(normalizeCommand('  Objects.   Case.   Details  '), 'Objects. Case. Details');
+});
+
+test('buildRecentCommands dedupes commands and keeps most recent first', () => {
+	const recent = buildRecentCommands('Objects.Case.details', [
+		'Profiles.Admin.View',
+		'Objects.Case.details',
+		'Objects.Account.fields',
+	]);
+
+	assert.deepEqual(recent, [
+		'Objects.Case.details',
+		'Profiles.Admin.View',
+		'Objects.Account.fields',
+	]);
+});
+
+test('buildRecentCommands caps results to MAX_RECENT_COMMANDS', () => {
+	const existing = Array.from({length: MAX_RECENT_COMMANDS + 5}, (_, index) => `Objects.Command${index}.view`);
+	const recent = buildRecentCommands('Objects.Newest.view', existing, MAX_RECENT_COMMANDS);
+
+	assert.equal(recent.length, MAX_RECENT_COMMANDS);
+	assert.equal(recent[0], 'Objects.Newest.view');
+});


### PR DESCRIPTION
### Motivation

- Provide users quick access to previously executed commands and let them pin frequently used commands for faster reuse. 
- Persist commands executed via navigation so the popup can surface meaningful history across sessions. 
- Keep history tidy by normalizing, deduping, and capping recents to avoid clutter. 

### Description

- Add a new storage-backed service `src/core/command-history.js` that exposes `addRecent`, `listRecent`, `pinCommand`, and `unpinCommand`, plus helpers `normalizeCommand` and `buildRecentCommands` (dedupe, most-recent-first, cap at 20). 
- Persist successful navigation commands by updating `NavigatorService.navigateToItem` to accept a `commandInput` and call `CommandHistoryService.addRecent`; update action wiring in `src/features/autocomplete/dom-utils.js` to pass the input string into navigation. 
- Render `Pinned` and `Recent` sections in `popup.html` and add UI wiring in `popus.js` to list history, support pin/unpin, and rehydrate the input (triggering autocomplete) when a command is selected. 
- Add styles for history UI in `styles/popup.css` and unit tests in `tests/command-history.test.js` covering normalization, dedupe/ordering, and max-cap behavior. 

### Testing

- Ran `npm test` and all tests passed (existing autocomplete/domain tests plus the new `command-history` tests). 
- Ran `npm run check:syntax` and the code passed syntax checks. 
- Ran `npm run lint` which failed due to pre-existing `no-unused-vars` warnings in unrelated files (`src/core/session-manager.js` and `src/utils/domain-validator.js`) and not because of these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5ec67ffac8327a73111055c395f1d)